### PR TITLE
Build with Stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ license = "MIT"
 repository = "https://github.com/johnshaw/magnetic"
 keywords = ["lock-free", "queue"]
 documentation = "http://johnshaw.github.io/magnetic/doc/magnetic"
+
+[features]
+unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,11 @@
 //! t2.join().unwrap();
 //! ```
 
-#![feature(asm)]
-#![feature(test)]
+#![cfg_attr(feature = "unstable", feature(test, asm))]
+
 #![deny(missing_docs)]
 
+#[cfg(feature = "unstable")]
 extern crate test;
 
 pub mod buffer;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,10 +3,16 @@ use std::ptr;
 
 use super::buffer::Buffer;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(feature="unstable", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 pub fn pause() {
     unsafe { asm!("PAUSE") };
+}
+
+#[cfg(all(not(feature="unstable"), any(target_arch = "x86", target_arch = "x86_64")))]
+#[inline(always)]
+pub fn pause() {
+    // nop
 }
 
 #[cfg(all(not(target_arch = "x86"), not(target_arch = "x86_64")))]


### PR DESCRIPTION
This changeset allows building this crate using the stable release of rust. Optionally with unstable rust using cargo build --features=unstable the inline asm!() is enabled allowing better power savings on x86
