### PR TITLE
Replace Sync impl with Clone impl

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -140,10 +140,9 @@ impl<T, B: Buffer<T>> Consumer<T> for MPMCConsumer<T, B> {
         let tail = q.tail.next.fetch_add(1, Ordering::Relaxed);
         let tail_plus_one = tail + 1;
         loop {
-            let ok = q.ok.load(Ordering::Acquire);
             if tail_plus_one <= q.head.curr.load(Ordering::Acquire) {
                 break;
-            } else if !ok {
+            } else if !q.ok.load(Ordering::Acquire) {
                 return Err(PopError::Disconnected);
             }
             spin_loop();
@@ -163,9 +162,8 @@ impl<T, B: Buffer<T>> Consumer<T> for MPMCConsumer<T, B> {
         loop {
             let tail = q.tail.curr.load(Ordering::Relaxed);
             let tail_plus_one = tail + 1;
-            let ok = q.ok.load(Ordering::Acquire);
             if tail_plus_one > q.head.curr.load(Ordering::Acquire) {
-                if ok {
+                if q.ok.load(Ordering::Acquire) {
                     return Err(TryPopError::Empty);
                 } else {
                     return Err(TryPopError::Disconnected);

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -140,10 +140,9 @@ impl<T, B: Buffer<T>> Consumer<T> for MPSCConsumer<T, B> {
         let tail = q.tail.load(Ordering::Relaxed);
         let tail_plus_one = tail + 1;
         loop {
-            let ok = q.ok.load(Ordering::Acquire);
             if tail_plus_one <= q.head.curr.load(Ordering::Acquire) {
                 break;
-            } else if !ok {
+            } else if !q.ok.load(Ordering::Acquire) {
                 return Err(PopError::Disconnected);
             }
             spin_loop();
@@ -160,9 +159,8 @@ impl<T, B: Buffer<T>> Consumer<T> for MPSCConsumer<T, B> {
         let tail = q.tail.load(Ordering::Relaxed);
         let tail_plus_one = tail + 1;
 
-        let ok = q.ok.load(Ordering::Acquire);
         if tail_plus_one > q.head.curr.load(Ordering::Acquire) {
-            if ok {
+            if q.ok.load(Ordering::Acquire) {
                 Err(TryPopError::Empty)
             } else {
                 Err(TryPopError::Disconnected)

--- a/src/spmc.rs
+++ b/src/spmc.rs
@@ -42,7 +42,6 @@ pub struct SPMCProducer<T, B: Buffer<T>> {
 }
 
 unsafe impl<T: Send, B: Buffer<T>> Send for SPMCProducer<T, B> {}
-unsafe impl<T: Send, B: Buffer<T>> Sync for SPMCProducer<T, B> {}
 
 /// Creates a new SPMC queue
 ///

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -125,10 +125,9 @@ impl<T, B: Buffer<T>> Consumer<T> for SPSCConsumer<T, B> {
         let tail = q.tail.load(Ordering::Relaxed);
         let tail_plus_one = tail + 1;
         loop {
-            let ok = q.ok.load(Ordering::Acquire);
             if tail_plus_one <= q.head.load(Ordering::Acquire) {
                 break;
-            } else if !ok {
+            } else if !q.ok.load(Ordering::Acquire) {
                 return Err(PopError::Disconnected);
             }
             spin_loop();
@@ -145,9 +144,8 @@ impl<T, B: Buffer<T>> Consumer<T> for SPSCConsumer<T, B> {
         let tail = q.tail.load(Ordering::Relaxed);
         let tail_plus_one = tail + 1;
 
-        let ok = q.ok.load(Ordering::Acquire);
         if tail_plus_one > q.head.load(Ordering::Acquire) {
-            if ok {
+            if q.ok.load(Ordering::Acquire) {
                 Err(TryPopError::Empty)
             } else {
                 Err(TryPopError::Disconnected)


### PR DESCRIPTION
- [Replace Sync impl with Clone impl](https://github.com/johnshaw/magnetic/commit/d2b52cd57e5553787b1b6b49c0d4f46b03a43ea1): Seemed like a copy paste error, so I've removed it
- [Only do ok check in Consumers when required](https://github.com/johnshaw/magnetic/commit/1b085445700efd75dac46c678010fa159719f078): Couldn't find a reason that the check cannot happen later, so I've moved it inside the if block.
- [Replace Sync impl with Clone impl](https://github.com/johnshaw/magnetic/commit/d2b52cd57e5553787b1b6b49c0d4f46b03a43ea1): This is a breaking change, but it makes this crate much more ergonomic as cloning is more simpler than using `Arc<MPSCProducer>` or a new type.
- Currently we need to put the `M` part like `MPSCProducer` behind a shared reference like `Arc`, but it is internally already wrapping another `Arc`, so this change also removes the need for nested Arcs. 
- Also, for the `S` part like `MPSCConsumer`, we don't need to use the `ok` AtomicBool to know if the producer is still alive, we can just use `Arc::strong_count` to check that.
- `Arc::strong_count` uses `Relaxed` load internally, so `SCConsumer` should be slightly faster in most cases.