### PR TITLE
Use Relaxed ordering for producer(s)/consumer(s)

### DIFF
--- a/src/buffer/array.rs
+++ b/src/buffer/array.rs
@@ -30,7 +30,7 @@ impl<T, const CAP: usize> Buffer<T> for ArrayBuffer<T, CAP> {
 
     #[inline(always)]
     fn at(&self, idx: usize) -> *const UnsafeCell<MaybeUninit<T>> {
-        &self.0[idx % CAP] as * const _
+        &self.0[idx % CAP] as *const _
     }
 }
 

--- a/src/buffer/dynamic.rs
+++ b/src/buffer/dynamic.rs
@@ -6,7 +6,7 @@ use super::Buffer;
 
 /// Holds data allocated from the heap at run time
 pub struct DynamicBuffer<T> {
-    items: Box<[UnsafeCell<MaybeUninit<T>>]>
+    items: Box<[UnsafeCell<MaybeUninit<T>>]>,
 }
 
 impl<T> DynamicBuffer<T> {
@@ -18,7 +18,7 @@ impl<T> DynamicBuffer<T> {
             let mut vec = Vec::with_capacity(size);
             unsafe { vec.set_len(size) };
             Ok(DynamicBuffer {
-                items: vec.into_boxed_slice()
+                items: vec.into_boxed_slice(),
             })
         } else {
             Err("Buffer size must be greater than 0")
@@ -46,7 +46,7 @@ impl<T> Buffer<T> for DynamicBuffer<T> {
 /// faster runtime performance due to the use of a mask instead of modulus
 /// when computing buffer indexes.
 pub struct DynamicBufferP2<T> {
-    items: Box<[UnsafeCell<MaybeUninit<T>>]>
+    items: Box<[UnsafeCell<MaybeUninit<T>>]>,
 }
 
 impl<T> DynamicBufferP2<T> {
@@ -61,7 +61,7 @@ impl<T> DynamicBufferP2<T> {
                     let mut vec = Vec::with_capacity(size);
                     unsafe { vec.set_len(size) };
                     vec.into_boxed_slice()
-                }
+                },
             }),
             _ => Err("Buffer size must be a power of two"),
         }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -34,7 +34,7 @@ impl<T, B: Buffer<T>> Buffer<T> for Box<B> {
         (**self).size()
     }
 
-    fn at(&self, idx: usize) -> * const UnsafeCell<MaybeUninit<T>> {
+    fn at(&self, idx: usize) -> *const UnsafeCell<MaybeUninit<T>> {
         (**self).at(idx)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,20 +142,30 @@ impl std::error::Error for TryPopError {}
 /// The consumer end of the queue allows for sending data. `Producer<T>` is
 /// always `Send`, but is only `Sync` for multi-producer (MPSC, MPMC) queues.
 pub trait Producer<T> {
+    /// Check if this channel is closed.
+    fn is_closed(&self) -> bool;
+
     /// Add value to front of the queue. This method will block if the queue
     /// is currently full.
+    /// If the channel is closed, this function will continue succeeding until
+    /// the queue becomes full.
     fn push(&self, value: T) -> Result<(), PushError<T>>;
 
     /// Attempt to add a value to the front of the queue. If the value was
     /// added successfully, `None` will be returned. If unsuccessful, `value`
     /// will be returned. An unsuccessful push indicates that the queue was
     /// full.
+    /// If the channel is closed, this function will continue succeeding until
+    /// the queue becomes full.
     fn try_push(&self, value: T) -> Result<(), TryPushError<T>>;
 }
 
 /// The consumer end of the queue allows for receiving data. `Consumer<T>` is
 /// always `Send`, but is only `Sync` for multi-consumer (SPMC, MPMC) queues.
 pub trait Consumer<T> {
+    /// Check if this channel is closed.
+    fn is_closed(&self) -> bool;
+
     /// Remove value from the end of the queue. This method will block if the
     /// queue is currently empty.
     fn pop(&self) -> Result<T, PopError>;

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -6,6 +6,7 @@
 //! the `MPSCProducer` is `Send` and `Sync` while the `MPSCConsumer` is `Send`
 //! and `!Sync`.
 
+use std::cell::Cell;
 use std::hint::spin_loop;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -28,7 +29,10 @@ struct MPSCQueue<T, B: Buffer<T>> {
 /// Consumer end of the queue. Implements the trait `Consumer<T>`.
 pub struct MPSCConsumer<T, B: Buffer<T>> {
     queue: Arc<MPSCQueue<T, B>>,
-    _not_sync: PhantomData<std::cell::Cell<()>>,
+    /// A copy of `queue.head` for quick access.
+    ///
+    /// This value can be stale and sometimes needs to be resynchronized with `queue.head`.
+    cached_head: Cell<usize>,
 }
 
 /// Producer end of the queue. Implements the trait `Producer<T>`.
@@ -77,7 +81,7 @@ pub fn mpsc_queue<T, B: Buffer<T>>(buf: B) -> (MPSCProducer<T, B>, MPSCConsumer<
         },
         MPSCConsumer {
             queue,
-            _not_sync: PhantomData,
+            cached_head: Cell::new(0),
         },
     )
 }
@@ -156,13 +160,17 @@ impl<T, B: Buffer<T>> Consumer<T> for MPSCConsumer<T, B> {
         let tail = q.tail.load(Ordering::Relaxed);
         let tail_plus_one = tail + 1;
 
-        loop {
-            if q.head.curr.load(Ordering::Acquire) >= tail_plus_one {
-                break;
-            } else if Arc::strong_count(q) < 2 {
-                return Err(PopError::Disconnected);
+        if self.cached_head.get() < tail_plus_one {
+            loop {
+                let head = q.head.curr.load(Ordering::Acquire);
+                if head >= tail_plus_one {
+                    self.cached_head.set(head);
+                    break;
+                } else if Arc::strong_count(q) < 2 {
+                    return Err(PopError::Disconnected);
+                }
+                spin_loop();
             }
-            spin_loop();
         }
 
         let v = unsafe { buf_read(&q.buf, tail) };
@@ -175,12 +183,16 @@ impl<T, B: Buffer<T>> Consumer<T> for MPSCConsumer<T, B> {
         let tail = q.tail.load(Ordering::Relaxed);
         let tail_plus_one = tail + 1;
 
-        if q.head.curr.load(Ordering::Acquire) < tail_plus_one {
-            return if Arc::strong_count(q) < 2 {
-                Err(TryPopError::Disconnected)
-            } else {
-                Err(TryPopError::Empty)
-            };
+        if self.cached_head.get() < tail_plus_one {
+            let head = q.head.curr.load(Ordering::Acquire);
+            if head < tail_plus_one {
+                return if Arc::strong_count(q) < 2 {
+                    Err(TryPopError::Disconnected)
+                } else {
+                    Err(TryPopError::Empty)
+                };
+            }
+            self.cached_head.set(head);
         }
 
         let v = unsafe { buf_read(&q.buf, tail) };


### PR DESCRIPTION
- The first change is just minor code style changes to bring different implementations in sync.
- In the 2nd change, I've moved is_closed check after is_full check. This way, you can optimistically push items until the queue becomes full & only then you'll know if the channel got closed. I've also added a is_closed flag so that you can manually check if the queue is closed from time to time.
- In the 3rd change, I've changed the memory Orderings for the is_closed atomics to Relaxed. Since we don't use the values of these for indexing, we don't need use the more strict memory barrier.
- In the 4th change, I've made it so that the single side of spsc/mpsc/spmc are able to cache the head or the tail of the other side to avoid an expensive load every time. So now, the sp push side can continue pushing without checking the tail up to the buffer len. Similarly, the sc side can continue popping elements until it has read all the elements from the last load.

All these changes add up to significant improvement in performance, especially the last change:
```
mpmc::ping_pong         time:   [276.64 ns 276.66 ns 276.68 ns]
                        change: [-20.062% -20.050% -20.037%] (p = 0.00 < 0.05)
mpmc::ping_pong_try     time:   [451.81 ns 451.83 ns 451.85 ns]
                        change: [+6.5298% +6.6577% +6.7261%] (p = 0.00 < 0.05)
mpsc::ping_pong         time:   [274.70 ns 274.73 ns 274.76 ns]
                        change: [-12.739% -12.726% -12.711%] (p = 0.00 < 0.05)
mpsc::ping_pong_try     time:   [466.36 ns 466.38 ns 466.41 ns]
                        change: [-4.5087% -4.4944% -4.4815%] (p = 0.00 < 0.05)
mpsc::ping_pong_std     time:   [7.3077 µs 7.3465 µs 7.3823 µs]
                        change: [+0.3924% +0.8050% +1.2300%] (p = 0.00 < 0.05)
spmc::ping_pong         time:   [205.56 ns 205.57 ns 205.58 ns]
                        change: [-37.772% -37.767% -37.762%] (p = 0.00 < 0.05)
spmc::ping_pong_try     time:   [276.08 ns 276.09 ns 276.10 ns]
                        change: [-27.241% -27.235% -27.229%] (p = 0.00 < 0.05)
spsc::ping_pong         time:   [220.11 ns 220.13 ns 220.15 ns]
                        change: [-26.017% -26.009% -26.001%] (p = 0.00 < 0.05)
spsc::ping_pong_try     time:   [266.36 ns 266.39 ns 266.42 ns]
                        change: [-29.223% -29.211% -29.195%] (p = 0.00 < 0.05)
spsc uncontended push   time:   [2.6856 ns 2.7026 ns 2.7216 ns]
                        change: [-66.540% -66.158% -65.745%] (p = 0.00 < 0.05)
spsc uncontended push (full)
                        time:   [1.0681 ns 1.0682 ns 1.0682 ns]
                        change: [-96.816% -96.771% -96.737%] (p = 0.00 < 0.05)
spsc uncontended pop    time:   [2.1455 ns 2.1457 ns 2.1458 ns]
                        change: [-95.614% -95.049% -94.406%] (p = 0.00 < 0.05)
spsc uncontended pop (empty)
                        time:   [947.97 ps 948.17 ps 948.38 ps]
                        change: [-10.788% -10.750% -10.712%] (p = 0.00 < 0.05)
```