### PR TITLE
Add support for sending non-sync values

### DIFF
--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -25,6 +25,8 @@ struct MPSCQueue<T, B: Buffer<T>> {
     _marker: PhantomData<T>,
 }
 
+unsafe impl<T: Send, B: Buffer<T>> Sync for MPSCQueue<T, B> {}
+
 /// Consumer end of the queue. Implements the trait `Consumer<T>`.
 pub struct MPSCConsumer<T, B: Buffer<T>> {
     queue: Arc<MPSCQueue<T, B>>,

--- a/src/spmc.rs
+++ b/src/spmc.rs
@@ -25,6 +25,8 @@ struct SPMCQueue<T, B: Buffer<T>> {
     _marker: PhantomData<T>,
 }
 
+unsafe impl<T: Send, B: Buffer<T>> Sync for SPMCQueue<T, B> {}
+
 /// Consumer end of the queue. Implements the trait `Consumer<T>`.
 pub struct SPMCConsumer<T, B: Buffer<T>> {
     queue: Arc<SPMCQueue<T, B>>,


### PR DESCRIPTION
This PR adds manual implementations of `Sync` for `SPSCQueue`, `SPMCQueue`, and `MPSCQueue`.

The motivation for this change came from wanting to be able to send other producers and consumers via an `SPSCQueue`, although this extends to any value types that are `Send` but not `Sync`. Consider the following example:

```rust
use magnetic::{Producer, buffer::dynamic::DynamicBuffer, spsc::spsc_queue};

fn main() {
    let (p, _) = spsc_queue(DynamicBuffer::new(32).unwrap());
    let (p2, _) = spsc_queue(DynamicBuffer::<i32>::new(32).unwrap());
    std::thread::spawn(move || p.push(p2));
    //                 ^^^^ `Cell<()>` cannot be shared between threads safely
}
```

This doesn't compile without this PR, because:
- `p2` is `!Sync` (enforced by the `Cell<()>` referred to in the error),
- ...which causes `p`'s `Arc<SPSCQueue<_>` field to also be `!Sync`,
- ...which causes `p` to also become `!Send`, because `Arc<T>` requires `T: Sync` for it to implement `Send`.

Adding a manual implementation of `Sync` for `SPSCQueue` when `T: Send` allows the example above to compile.
